### PR TITLE
Fix for distorted deck images on replays

### DIFF
--- a/less/layout.less
+++ b/less/layout.less
@@ -162,6 +162,7 @@
 
 		> figure {
 			height: 70%;
+			width: 70%
 			position: relative;
 			padding: 0;
 			margin: -9% 0 0 0;


### PR DESCRIPTION
On replay pages cardbacks used for cards in decks have wrong width value.
Screenshot:
![image](https://user-images.githubusercontent.com/8514685/64912568-fd0b6180-d739-11e9-8b12-f867524a846c.png)


Browser&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;| Current state&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;| Patch state
Chrome 77 | Bug is present&nbsp;&nbsp;&nbsp;&nbsp;| Fixed
Firefox 69&nbsp;&nbsp;&nbsp;| Bug not present | No changes
Edge 44&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;| Bug not present | No changes

- [x] I have read the [Contributing Guidelines](https://github.com/HearthSim/Hearthstone-Deck-Tracker/blob/master/CONTRIBUTING.md#contributing)
- [x] I have already signed the CLA <!--- See https://github.com/HearthSim/Hearthstone-Deck-Tracker/blob/master/CONTRIBUTING.md#contributor-license-agreement -->